### PR TITLE
Update 4x4keyboard.ino

### DIFF
--- a/4x4keyboard.ino
+++ b/4x4keyboard.ino
@@ -31,7 +31,7 @@ static const uint8_t ColPins[NUM_COLS] = {6,7,8,9};
 
 //// Global variables
 // Counter for how long a button has been pressed
-static uint8_t debounce_count[NUM_COLS][NUM_ROWS];
+static uint8_t debounce_count[NUM_ROWS][NUM_COLS];
 
 void setup()
 {


### PR DESCRIPTION
The debounce counter array is initiated in reverse of how it's used in the code. This works somehow for a 4x4 keyboard or any square one I suppose but not for rectangle one, a 4x5 in my case.